### PR TITLE
Fix MySQL-ism in db/upgrade.

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -149,7 +149,7 @@ function xmldb_zoom_upgrade($oldversion) {
         $dbman->change_field_notnull($table, $field);
         $dbman->change_field_default($table, $field);
         // Meeting is recurring if type is 3.
-        $DB->execute('UPDATE {zoom} SET type = (type = 3)');
+        $DB->execute('UPDATE {zoom} SET type = cast((type = 3) as int)');
         $dbman->rename_field($table, $field, 'recurring');
 
         // Zoom savepoint reached.


### PR DESCRIPTION
Fix MySQL-ism in db/upgrade.php -- without this, upgrade dies for PostgreSQL users. Not tested on MySQL, but should be correct according to docs.