### PR TITLE
Issue #14 - Removed BOM from lang/en/zoom.php

### DIFF
--- a/lang/en/zoom.php
+++ b/lang/en/zoom.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 // This file is part of the Zoom plugin for Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify


### PR DESCRIPTION
It does't show in the github diff, but the file had a BOM

```
$ git diff
diff --git a/lang/en/zoom.php b/lang/en/zoom.php
index ed0aee3..5dee773 100644
--- a/lang/en/zoom.php
+++ b/lang/en/zoom.php
@@ -1,4 +1,4 @@
-<U+FEFF><?php
+<?php
 // This file is part of the Zoom plugin for Moodle - http://moodle.org/
 //
 // Moodle is free software: you can redistribute it and/or modify
```