### PR TITLE
use Moodle's curl class to automatically support proxy configuration

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -71,27 +71,15 @@ class mod_zoom_webservice {
 
         $postfields = http_build_query($data, '', '&');
 
-        $ch = curl_init();
-        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-        curl_setopt($ch, CURLOPT_URL, $url);
-        curl_setopt($ch, CURLOPT_POST, 1);
-        curl_setopt($ch, CURLOPT_POSTFIELDS, $postfields);
-        curl_setopt($ch, CURLOPT_HTTPHEADER, array(
-            'Content-Type: application/x-www-form-urlencoded; charset=utf-8'
-            ));
-        curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-        curl_setopt($ch, CURLOPT_FAILONERROR, true);
-
-        $response = curl_exec($ch);
-        if ($response === false) {
+        $curl = new curl();
+        $curl->setHeader('Content-Type: application/x-www-form-urlencoded; charset=utf-8');
+        $response = $curl->post($url, $postfields, array('CURLOPT_FAILONERROR' => true));
+        if ($curl->get_errno()) {
             // Curl error.
-            $error = curl_error($ch);
-            curl_close($ch);
-            $this->lasterror = $error;
-            throw new moodle_exception('errorwebservice', 'mod_zoom', '', $error);
+            $this->lasterror = $curl->error;
+            throw new moodle_exception('errorwebservice', 'mod_zoom', '', $curl->error);
         }
 
-        curl_close($ch);
         $response = json_decode($response);
         if (isset($response->error)) {
             // Web service error.

--- a/lang/en/zoom.php
+++ b/lang/en/zoom.php
@@ -115,6 +115,7 @@ $string['zoomerr'] = 'An error occured with Zoom.'; // Generic error.
 $string['zoomerr_apisettings_invalid'] = 'The Zoom API key and/or secret are invalid. Please ensure they are correct.';
 $string['zoomerr_apisettings_missing'] = 'Please configure the Zoom API key and secret.';
 $string['zoomerr_apiurl_404'] = 'The Zoom API url could not be found; please check the setting.';
+$string['zoomerr_apiurl_error'] = 'The Zoom API could not be contacted; please check your server error log.';
 $string['zoomerr_apiurl_unresolved'] = 'The Zoom API url could not be resolved; please check the setting.';
 $string['zoomerr_meetingnotfound'] = 'This meeting does not exist or has expired.';
 $string['zoomerr_usernotfound'] = 'You are using Zoom for the first time, so you must enable your Zoom account by logging in to <a href="{$a}" target="_blank">{$a}</a> with your login credentials. Once you\'ve activated your Zoom account, reload this page and continue setting up your meeting.';

--- a/settings.php
+++ b/settings.php
@@ -50,6 +50,10 @@ if ($ADMIN->fulltree) {
             } else if (strpos($error, "Couldn't resolve host") !== false) {
                 $status = 'zoomerr_apiurl_unresolved';
                 $notifyclass = 'notifyproblem';
+            } else if (strpos($error, "The requested URL returned error:") !== false) {
+                $status = 'zoomerr_apiurl_error';
+                $notifyclass = 'notifyproblem';
+                debugging('Zoom error: ' . $error, DEBUG_NORMAL);
             }
         }
         $statusmessage = $OUTPUT->notification(get_string('connectionstatus', 'zoom') .


### PR DESCRIPTION
By using Moodle's abstraction to cURL you get proxy configuration handled automatically, and it helps simplify the code.

This change also reports other kinds of connectivity errors, separate from the 404 test that already exists, during the connection test in the settings page. The actual error is logged to the webserver at Moodle's 'normal' debug level.