### PR TITLE
Suggestion: Allow full zoom object in calendar description object

### DIFF
--- a/exportical.php
+++ b/exportical.php
@@ -43,7 +43,7 @@ $context = context_module::instance($cm->id);
 $PAGE->set_context($context);
 
 require_capability('mod/zoom:view', $context);
-
+$config = get_config('mod_zoom');
 // Start ical file.
 $ical = new iCalendar;
 $ical->add_property('method', 'PUBLISH');
@@ -62,7 +62,7 @@ $event->add_property('dtend', Bennu::timestamp_to_datetime($zoom->start_time + $
 
 // Compute and add description property to event.
 $convertedtext = html_to_text($zoom->intro);
-$descriptiontext = get_string('calendardescriptionURL', 'mod_zoom', $zoom->join_url);
+$descriptiontext = get_string('calendardescriptionURL', 'mod_zoom', $config->newstringtemplate ? $zoom : $zoom->join_url);
 if (!empty($convertedtext)) {
     $descriptiontext .= get_string('calendardescriptionintro', 'mod_zoom', $convertedtext);
 }

--- a/settings.php
+++ b/settings.php
@@ -105,5 +105,9 @@ if ($ADMIN->fulltree) {
     $defaultjoinbeforehost = new admin_setting_configcheckbox('mod_zoom/defaultjoinbeforehost', get_string('option_jbh', 'zoom'),
             '', 0, 1, 0);
     $settings->add($defaultjoinbeforehost);
+    
+    $newstringtemplate = new admin_setting_configcheckbox('mod_zoom/newstringtemplate', get_string('option_nst', 'zoom'),
+            '', 0, 1, 0);
+    $settings->add($newstringtemplate);
 
 }


### PR DESCRIPTION
This allows us to include the Zoom meeting ID separate from the URL for instance, to show call-in instructions in the calendar invite.  The code in this PR is a suggested way to do it without breaking old installations (they would have to set a config checkbox to change what {$a} is populated with)

It is up to you the best way to do this ultimately of course! I also have not tested this code yet (though I have modified our copy to give the full $zoom object as in e8ebf3c and it works great.  