### PR TITLE
zoom_update_instance: correctly return boolean

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -91,7 +91,7 @@ function zoom_add_instance(stdClass $zoom, mod_zoom_mod_form $mform = null) {
  *
  * @param stdClass $zoom An object from the form in mod_form.php
  * @param mod_zoom_mod_form $mform The form instance (included because the function is used as a callback)
- * @return int The id of the newly inserted zoom record
+ * @return boolean Success/Failure
  */
 function zoom_update_instance(stdClass $zoom, mod_zoom_mod_form $mform = null) {
     global $CFG, $DB;
@@ -108,12 +108,16 @@ function zoom_update_instance(stdClass $zoom, mod_zoom_mod_form $mform = null) {
 
     // Update meeting on Zoom.
     $service = new mod_zoom_webservice();
-    $service->update_meeting($zoom);
+    try {
+        $service->update_meeting($zoom);
+    } catch (moodle_exception $error) {
+        return false;
+    }
 
     zoom_calendar_item_update($zoom);
     zoom_grade_item_update($zoom);
 
-    return $zoom->id;
+    return true;
 }
 
 /**


### PR DESCRIPTION
Hi all,

We ran into an issue where `zoom_update_instance()` was calling `update_meeting()` and allowing a Zoom "meeting not found" exception bubble up to the default exception handler. This was breaking multi-update tools like the OU Dates Report. The `zoom_update_instance()` function is expected by Moodle to return a boolean anyway, so it seems like this solution is more aligned with what Moodle is expecting.

If you would like additional changes, please let me know. Ideas that I had included:
* moving the calendar and grade item updates before the webservice update (if we want to update everything locally even if the remote fails)
* moving the `update_record()` after the webservice update (so that we don't update anything locally if the remote is failing)