### PR TITLE
adding new 'not found on this account' message to list of user errors

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -182,7 +182,8 @@ function zoom_is_meeting_gone_error($error) {
  * @return bool
  */
 function zoom_is_user_not_found_error($error) {
-    return strpos($error, 'not exist') !== false || strpos($error, 'not belong to this account') !== false;
+    return strpos($error, 'not exist') !== false || strpos($error, 'not belong to this account') !== false
+        || strpos($error, 'not found on this account') !== false;
 }
 
 /**


### PR DESCRIPTION
Starting June 22, 2019, we started seeing an error when student users without Zoom accounts tried to join a meeting:
![Screenshot 2019-07-22 at 3 01 23 PM](https://user-images.githubusercontent.com/18444936/61739406-f66ff780-ad51-11e9-9580-62e5a58c1559.png)

I'm not sure if Zoom recently changed the language in their errors (trying to confirm with them), but since this is only occurring when the plugin is checking whether the user is the host, this error message should be added to the list of responses that do not throw a general Moodle error, but just return no user id.