### PR TITLE
webservice: 429 Retry-After improvements

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -78,7 +78,7 @@ class zoom_api_retry_failed_exception extends moodle_exception {
         $this->response = $response;
         $a = new stdClass();
         $a->response = $response;
-        $a->maxretries = MAX_RETRIES;
+        $a->maxretries = mod_zoom_webservice::MAX_RETRIES;
         parent::__construct('zoomerr_maxretries', 'mod_zoom', '', $a);
     }
 }


### PR DESCRIPTION
* If it's going to exit anyway based on number of retries, do that before calculating sleep time.
* If they're telling us to wait more than one minute, just give up.

Hi @rlorenzo! I noticed that e88f877 might behave strangely when we're told to wait for more than one minute (as in, I think it will do 20 requests back-to-back, instantly hitting the retry maximum). Also, it was doing work that would then go unused.

It might be good to have a different exception message and constant like `MAX_RETRY_WAIT` so that the 60 second max wait is more visible.

I don't think this code is ready to be merged, because I want to know what your preferences are.