### PR TITLE
Custom completion

### DIFF
--- a/backup/moodle2/backup_zoom_stepslib.php
+++ b/backup/moodle2/backup_zoom_stepslib.php
@@ -50,7 +50,7 @@ class backup_zoom_activity_structure_step extends backup_activity_structure_step
             'created_at', 'host_id', 'name', 'start_time', 'timemodified',
             'recurring', 'webinar', 'duration', 'timezone', 'password', 'option_jbh',
             'option_start_type', 'option_host_video', 'option_participants_video',
-            'option_audio', 'status'));
+            'option_audio', 'status', 'completionjoin'));
 
         // If we had more elements, we would build the tree here.
 

--- a/db/install.xml
+++ b/db/install.xml
@@ -34,6 +34,7 @@
         <FIELD NAME="option_authenticated_users" TYPE="int" LENGTH="1" NOTNULL="false" DEFAULT="0" SEQUENCE="false"/>
         <FIELD NAME="exists_on_zoom" TYPE="int" LENGTH="1" NOTNULL="true" DEFAULT="1" SEQUENCE="false" COMMENT="Whether the meeting can be found on Zoom servers. Usually should be true, should only be false if API call returned that meeting can't be found."/>
         <FIELD NAME="alternative_hosts" TYPE="text" NOTNULL="false" SEQUENCE="false"/>
+        <FIELD NAME="completionjoin" TYPE="int" LENGTH="2" NOTNULL="true" DEFAULT="0" SEQUENCE="false" COMMENT="If this field is set to 1, then the activity will be automatically marked as 'complete' once the user joins the meeting."/>
       </FIELDS>
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -440,7 +440,7 @@ function xmldb_zoom_upgrade($oldversion) {
             $dbman->add_field($table, $field);
         }
         
-        upgrade_mod_savepoint(true, 2020052100, 'zoom');
+        upgrade_mod_savepoint(true, 2020071500, 'zoom');
     }
 
     return true;

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -431,5 +431,17 @@ function xmldb_zoom_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2020052100, 'zoom');
     }
 
+    if ($oldversion < 2020052100) {
+        // Add completionjoin.
+        
+        $table = new xmldb_table('zoom');
+        $field = new xmldb_field('completionjoin', XMLDB_TYPE_INTEGER, '2', null, XMLDB_NOTNULL, null, '0');
+        if (!$dbman->field_exists($table, $field)) {
+            $dbman->add_field($table, $field);
+        }
+        
+        upgrade_mod_savepoint(true, 2020052100, 'zoom');
+    }
+
     return true;
 }

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -431,7 +431,7 @@ function xmldb_zoom_upgrade($oldversion) {
         upgrade_mod_savepoint(true, 2020052100, 'zoom');
     }
 
-    if ($oldversion < 2020052100) {
+    if ($oldversion < 2020071500) {
         // Add completionjoin.
         
         $table = new xmldb_table('zoom');

--- a/lang/en/zoom.php
+++ b/lang/en/zoom.php
@@ -45,6 +45,7 @@ $string['calendardescriptionURL'] = 'Meeting join URL: {$a}.';
 $string['calendardescriptionintro'] = "\nDescription:\n{\$a}";
 $string['calendariconalt'] = 'Calendar icon';
 $string['clickjoin'] = 'Clicked join meeting button';
+$string['completionjoin'] = 'Student must join the meeting to complete this activity';
 $string['connectionok'] = 'Connection working.';
 $string['connectionfailed'] = 'Connection failed: ';
 $string['connectionstatus'] = 'Connection status';

--- a/lib.php
+++ b/lib.php
@@ -590,7 +590,7 @@ function zoom_get_completion_state($course, $cm, $userid, $type) {
                     WHERE component = 'mod_zoom' AND action = 'clicked'
                       AND target = 'join_meeting_button' 
                       AND objectid = :zoomid AND userid = :userid";
-        return $DB->get_field_sql($logsql, array('userid'=>$userid,'zoomid'=>$zoom->id));
+        return $DB->get_field_sql($logsql, array('userid' => $userid, 'zoomid' => $zoom->id));
     } else {
         // Completion option is not enabled so just return $type
         return $type;

--- a/lib.php
+++ b/lib.php
@@ -49,6 +49,7 @@ function zoom_supports($feature) {
         case FEATURE_GROUPMEMBERSONLY:
         case FEATURE_MOD_INTRO:
         case FEATURE_SHOW_DESCRIPTION:
+        case FEATURE_COMPLETION_HAS_RULES:
             return true;
         default:
             return null;

--- a/lib.php
+++ b/lib.php
@@ -585,23 +585,12 @@ function zoom_get_completion_state($course, $cm, $userid, $type) {
 
     // If completion option is enabled, evaluate it and return true/false 
     if($zoom->completionjoin) {
-        $participantsql = "SELECT COUNT(zmp.id) AS participant, COUNT(zmd.id) AS details
-                             FROM {zoom_meeting_details} zmd
-                        LEFT JOIN {zoom_meeting_participants} zmp ON zmp.detailsid = zmd.id 
-                            WHERE zmd.zoomid = :zoomid AND zmp.userid = :userid";
-        $participants = $DB->get_record_sql($participantsql, array('userid'=>$userid,'zoomid'=>$zoom->id));
-
-        // If no detail record found, it could be due to a delay in the cron, so check logs too
-        if(!$participants->details){
-           $logsql = "SELECT COUNT(1) 
-                        FROM mdl_logstore_standard_logs l 
-                       WHERE component = 'mod_zoom' AND action = 'clicked'
-                         AND target = 'join_meeting_button' 
-                         AND objectid = :zoomid AND userid = :userid";
-           return $DB->get_field_sql($logsql, array('userid'=>$userid,'zoomid'=>$zoom->id));
-        } else {
-           return $participants->participant;
-        }
+        $logsql = "SELECT COUNT(1) 
+                     FROM {logstore_standard_log} l 
+                    WHERE component = 'mod_zoom' AND action = 'clicked'
+                      AND target = 'join_meeting_button' 
+                      AND objectid = :zoomid AND userid = :userid";
+        return $DB->get_field_sql($logsql, array('userid'=>$userid,'zoomid'=>$zoom->id));
     } else {
         // Completion option is not enabled so just return $type
         return $type;

--- a/lib.php
+++ b/lib.php
@@ -584,7 +584,7 @@ function zoom_get_completion_state($course, $cm, $userid, $type) {
     $zoom = $DB->get_record('zoom', array('id' => $cm->instance), '*', MUST_EXIST);
 
     // If completion option is enabled, evaluate it and return true/false 
-    if($zoom->completionjoin) {
+    if ($zoom->completionjoin) {
         $logsql = "SELECT COUNT(1) 
                      FROM {logstore_standard_log} l 
                     WHERE component = 'mod_zoom' AND action = 'clicked'

--- a/loadmeeting.php
+++ b/loadmeeting.php
@@ -66,16 +66,16 @@ if ($userishost) {
         zoom_grade_item_update($zoom, $grades);
     }
 
-    // Update completion state
-    $completion = new completion_info($course);
-    if($completion->is_enabled($cm) && $zoom->completionjoin) {
-        $completion->update_state($cm,COMPLETION_COMPLETE);
-    }
-
     $nexturl = new moodle_url($zoom->join_url, array('uname' => fullname($USER)));
 }
 
 // Record user's clicking join.
 \mod_zoom\event\join_meeting_button_clicked::create(array('context' => $context, 'objectid' => $zoom->id, 'other' =>
         array('cmid' => $id, 'meetingid' => (int) $zoom->meeting_id, 'userishost' => $userishost)))->trigger();
+// Update completion state
+$completion = new completion_info($course);
+if($completion->is_enabled($cm) && $zoom->completionjoin) {
+    $completion->update_state($cm,COMPLETION_COMPLETE);
+}
+
 redirect($nexturl);

--- a/loadmeeting.php
+++ b/loadmeeting.php
@@ -75,7 +75,7 @@ if ($userishost) {
 // Update completion state
 $completion = new completion_info($course);
 if ($completion->is_enabled($cm) && $zoom->completionjoin) {
-    $completion->update_state($cm,COMPLETION_COMPLETE);
+    $completion->update_state($cm, COMPLETION_COMPLETE);
 }
 
 redirect($nexturl);

--- a/loadmeeting.php
+++ b/loadmeeting.php
@@ -66,6 +66,12 @@ if ($userishost) {
         zoom_grade_item_update($zoom, $grades);
     }
 
+    // Update completion state
+    $completion = new completion_info($course);
+    if($completion->is_enabled($cm) && $zoom->completionjoin) {
+        $completion->update_state($cm,COMPLETION_COMPLETE);
+    }
+
     $nexturl = new moodle_url($zoom->join_url, array('uname' => fullname($USER)));
 }
 

--- a/loadmeeting.php
+++ b/loadmeeting.php
@@ -74,7 +74,7 @@ if ($userishost) {
         array('cmid' => $id, 'meetingid' => (int) $zoom->meeting_id, 'userishost' => $userishost)))->trigger();
 // Update completion state
 $completion = new completion_info($course);
-if($completion->is_enabled($cm) && $zoom->completionjoin) {
+if ($completion->is_enabled($cm) && $zoom->completionjoin) {
     $completion->update_state($cm,COMPLETION_COMPLETE);
 }
 

--- a/mod_form.php
+++ b/mod_form.php
@@ -252,6 +252,30 @@ class mod_zoom_mod_form extends moodleform_mod {
 
         return $errors;
     }
+
+    /**
+     * Add any custom completion rules to the form.
+     *
+     * @return array Contains the names of the added form elements
+     */
+    public function add_completion_rules() {
+        $mform =& $this->_form;
+
+        $mform->addElement('advcheckbox', 'completionjoin', '', get_string('completionjoin', 'zoom'));
+        // Enable this completion rule by default.
+        $mform->setDefault('completionjoin', 1);
+        return array('completionjoin');
+    }
+
+    /**
+     * Determines if completion is enabled for this module.
+     *
+     * @param array $data
+     * @return bool
+     */
+    public function completion_rule_enabled($data) {
+        return !empty($data['completionjoin']);
+    }
 }
 
 /**

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2020061200;
+$plugin->version = 2020071500;
 $plugin->release = 'v3.1';
 $plugin->requires = 2017051500.00;
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
This addresses issue #43 by adding a new completion condition when a student joins the meeting.

I only realized as I was testing but this currently relies on logging being enabled to check completion, because Moodle's {module}_get_completion_state needs to be able to run its own check outside of loadmeeting.php. The alternative would be to add a new db table that records whenever a student clicks the join link in Moodle, similar to the {assign_submission} table. Let me know if you think this way would be preferred and I can update my branch.

Just fyi, the {zoom_meeting_participants} table is not useful for this because it only gets the participant date from Zoom after the fact, long after completion checks have run.