### PR TITLE
bad_request_exception: Include response message

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -99,7 +99,7 @@ class zoom_bad_request_exception extends moodle_exception {
     public function __construct($response, $errorcode) {
         $this->response = $response;
         $this->zoomerrorcode = $errorcode;
-        parent::__construct('errorwebservice_badrequest', 'mod_zoom');
+        parent::__construct('errorwebservice_badrequest', 'mod_zoom', '', $response);
     }
 }
 


### PR DESCRIPTION
#126 highlighted that the response message in the text string wasn't being passed by the exception constructor.

This doesn't solve that issue, but it should add a bit more context when the request fails.