### PR TITLE
Update webservice.php

### DIFF
--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -468,7 +468,7 @@ class mod_zoom_webservice {
             )
         );
         if (isset($zoom->intro)) {
-            $data['agenda'] = strip_tags($zoom->intro);
+            $data['agenda'] = $zoom->intro;
         }
         if (isset($CFG->timezone) && !empty($CFG->timezone)) {
             $data['timezone'] = $CFG->timezone;


### PR DESCRIPTION
This implements the discussed removal of Strip_tags() from the web service call so that a plain text description isn't sent to Zoom and then subsequently pulled back in plain text.