### PR TITLE
Update Zoom event when editing name via quick edit

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -114,7 +114,7 @@ function zoom_update_instance(stdClass $zoom, mod_zoom_mod_form $mform = null) {
     $service = new mod_zoom_webservice();
 
     // The object received from mod_form.php returns instance instead of id for some reason.
-    if(isset($zoom->instance)) {
+    if (isset($zoom->instance)) {
         $zoom->id = $zoom->instance;
     }
     $zoom->timemodified = time();


### PR DESCRIPTION
Implement callback function to update Zoom event when changing the name via quick edit. This will populate the changes in the Zoom app and the calendar.

Resolves #156

Demo: https://drive.google.com/file/d/13EspTscVAwdtIrGqj1QBnJSTB3aRSevd/view?usp=sharing


