### PR TITLE
Align all plugin settings prefixes - Fixes #180

### DIFF
--- a/classes/task/get_meeting_reports.php
+++ b/classes/task/get_meeting_reports.php
@@ -86,7 +86,7 @@ class get_meeting_reports extends \core\task\scheduled_task {
     public function execute($paramstart = null, $paramend = null, $hostuuids = null) {
         global $CFG, $DB;
 
-        $config = get_config('mod_zoom');
+        $config = get_config('zoom');
         if (empty($config->apikey)) {
             mtrace('Skipping task - ', get_string('zoomerr_apikey_missing', 'zoom'));
             return;
@@ -96,7 +96,7 @@ class get_meeting_reports extends \core\task\scheduled_task {
         }
 
         // See if we cannot make anymore API calls.
-        $retryafter = get_config('mod_zoom', 'retry-after');
+        $retryafter = get_config('zoom', 'retry-after');
         if (!empty($retryafter) && time() < $retryafter) {
             mtrace('Out of API calls, retry after ' . userdate($retryafter,
                     get_string('strftimedaydatetime', 'core_langconfig')));
@@ -109,7 +109,7 @@ class get_meeting_reports extends \core\task\scheduled_task {
 
         $this->debuggingenabled = debugging();
 
-        $starttime = get_config('mod_zoom', 'last_call_made_at');
+        $starttime = get_config('zoom', 'last_call_made_at');
         if (empty($starttime)) {
             // Zoom only provides data from 30 days ago.
             $starttime = strtotime('-30 days');
@@ -174,7 +174,7 @@ class get_meeting_reports extends \core\task\scheduled_task {
                     // unrecoverable error. Try to pick up where we left off.
                     if ($runningastask) {
                         // Only want to resume if we were processing all reports.
-                        set_config('last_call_made_at', $meetingtime - 1, 'mod_zoom');
+                        set_config('last_call_made_at', $meetingtime - 1, 'zoom');
                     }
 
                     $recordedallmeetings = false;
@@ -186,13 +186,13 @@ class get_meeting_reports extends \core\task\scheduled_task {
                 // Some unknown error, need to handle it so we can record
                 // where we left off.
                 if ($runningastask) {
-                    set_config('last_call_made_at', $meetingtime - 1, 'mod_zoom');
+                    set_config('last_call_made_at', $meetingtime - 1, 'zoom');
                 }
             }
         }
         if ($recordedallmeetings && $runningastask) {
             // All finished, so save the time that we set end time for the initial query.
-            set_config('last_call_made_at', $endtime, 'mod_zoom');
+            set_config('last_call_made_at', $endtime, 'zoom');
         }
     }
 

--- a/classes/task/update_meetings.php
+++ b/classes/task/update_meetings.php
@@ -61,7 +61,7 @@ class update_meetings extends \core\task\scheduled_task {
      */
     public function execute() {
         global $CFG, $DB;
-        $config = get_config('mod_zoom');
+        $config = get_config('zoom');
         if (empty($config->apikey)) {
             mtrace('Skipping task - ', get_string('zoomerr_apikey_missing', 'zoom'));
             return;

--- a/classes/webservice.php
+++ b/classes/webservice.php
@@ -119,7 +119,7 @@ class mod_zoom_webservice {
      * @throws moodle_exception Moodle exception is thrown for missing config settings.
      */
     public function __construct() {
-        $config = get_config('mod_zoom');
+        $config = get_config('zoom');
         if (!empty($config->apikey)) {
             $this->apikey = $config->apikey;
         } else {
@@ -178,7 +178,7 @@ class mod_zoom_webservice {
         global $CFG;
         $url = self::API_URL . $path;
         $method = strtolower($method);
-        $proxyhost = get_config('mod_zoom', 'proxyhost');
+        $proxyhost = get_config('zoom', 'proxyhost');
         $cfg = new stdClass();
         if (!empty($proxyhost)) {
             $cfg->proxyhost = $CFG->proxyhost;
@@ -252,7 +252,7 @@ class mod_zoom_webservice {
                         $timediff = $retryafter - time();
                         // If we have no API calls remaining, save retry-after.
                         if ($header['x-ratelimit-remaining'] == 0 && !empty($retryafter)) {
-                            set_config('retry-after', $retryafter, 'mod_zoom');
+                            set_config('retry-after', $retryafter, 'zoom');
                             throw new zoom_api_limit_exception($response->message,
                                     $response->code, $retryafter);
                         } else if (!(defined('PHPUNIT_TEST') && PHPUNIT_TEST)) {

--- a/loadmeeting.php
+++ b/loadmeeting.php
@@ -79,7 +79,7 @@ $completion->set_module_viewed($cm);
 
 // Upgrade host upon joining meeting, if host if not Licensed.
 if ($userishost) {
-    $config = get_config('mod_zoom');
+    $config = get_config('zoom');
     if (!empty($config->recycleonjoin)) {
         $service = new mod_zoom_webservice();
         $service->provide_license($zoom->host_id);

--- a/locallib.php
+++ b/locallib.php
@@ -337,7 +337,7 @@ function zoom_get_sessions_for_display($meetingid) {
  * @return array Array of booleans: [in progress, available, finished].
  */
 function zoom_get_state($zoom) {
-    $config = get_config('mod_zoom');
+    $config = get_config('zoom');
     $now = time();
 
     $firstavailable = $zoom->start_time - ($config->firstabletojoin * 60);

--- a/mod_form.php
+++ b/mod_form.php
@@ -45,7 +45,7 @@ class mod_zoom_mod_form extends moodleform_mod {
      */
     public function definition() {
         global $PAGE, $USER;
-        $config = get_config('mod_zoom');
+        $config = get_config('zoom');
         $PAGE->requires->js_call_amd("mod_zoom/form", 'init');
 
         $isnew = empty($this->_cm);
@@ -399,7 +399,7 @@ class mod_zoom_mod_form extends moodleform_mod {
         global $CFG, $USER;
         $errors = array();
 
-        $config = get_config('mod_zoom');
+        $config = get_config('zoom');
 
         // Only check for scheduled meetings.
         if (empty($data['recurring'])) {

--- a/participants.php
+++ b/participants.php
@@ -49,7 +49,7 @@ $PAGE->set_title("$course->shortname: $strname");
 $PAGE->set_heading($course->fullname);
 $PAGE->set_pagelayout('incourse');
 
-$maskparticipantdata = get_config('mod_zoom', 'maskparticipantdata');
+$maskparticipantdata = get_config('zoom', 'maskparticipantdata');
 // If participant data is masked then display a message stating as such and be done with it.
 if ($maskparticipantdata) {
     zoom_fatal_error(

--- a/report.php
+++ b/report.php
@@ -50,7 +50,7 @@ echo $OUTPUT->heading($strtitle, 4);
 
 $sessions = zoom_get_sessions_for_display($zoom->meeting_id);
 if (!empty($sessions)) {
-    $maskparticipantdata = get_config('mod_zoom', 'maskparticipantdata');
+    $maskparticipantdata = get_config('zoom', 'maskparticipantdata');
     $table = new html_table();
     $table->head = array(get_string('title', 'mod_zoom'),
                          get_string('starttime', 'mod_zoom'),

--- a/settings.php
+++ b/settings.php
@@ -47,54 +47,54 @@ if ($ADMIN->fulltree) {
         }
         $statusmessage = $OUTPUT->notification(get_string('connectionstatus', 'mod_zoom') .
                 ': ' . get_string($status, 'mod_zoom') . $errormessage, $notifyclass);
-        $connectionstatus = new admin_setting_heading('mod_zoom/connectionstatus', $statusmessage, '');
+        $connectionstatus = new admin_setting_heading('zoom/connectionstatus', $statusmessage, '');
         $settings->add($connectionstatus);
     }
 
     // Connection settings.
-    $settings->add(new admin_setting_heading('mod_zoom/connectionsettings',
+    $settings->add(new admin_setting_heading('zoom/connectionsettings',
             get_string('connectionsettings', 'mod_zoom'),
             get_string('connectionsettings_desc', 'mod_zoom')));
 
-    $apikey = new admin_setting_configtext('mod_zoom/apikey', get_string('apikey', 'mod_zoom'),
+    $apikey = new admin_setting_configtext('zoom/apikey', get_string('apikey', 'mod_zoom'),
             get_string('apikey_desc', 'mod_zoom'), '', PARAM_ALPHANUMEXT);
     $settings->add($apikey);
 
-    $apisecret = new admin_setting_configpasswordunmask('mod_zoom/apisecret', get_string('apisecret', 'mod_zoom'),
+    $apisecret = new admin_setting_configpasswordunmask('zoom/apisecret', get_string('apisecret', 'mod_zoom'),
             get_string('apisecret_desc', 'mod_zoom'), '');
     $settings->add($apisecret);
 
-    $zoomurl = new admin_setting_configtext('mod_zoom/zoomurl', get_string('zoomurl', 'mod_zoom'),
+    $zoomurl = new admin_setting_configtext('zoom/zoomurl', get_string('zoomurl', 'mod_zoom'),
             get_string('zoomurl_desc', 'mod_zoom'), '', PARAM_URL);
     $settings->add($zoomurl);
 
-    $proxyhost = new admin_setting_configtext('mod_zoom/proxyhost',
+    $proxyhost = new admin_setting_configtext('zoom/proxyhost',
             get_string('option_proxyhost', 'mod_zoom'),
             get_string('option_proxyhost_desc', 'mod_zoom'), '', '/^[a-zA-Z0-9.-]+:[0-9]+$|^$/');
     $settings->add($proxyhost);
 
     // License settings.
-    $settings->add(new admin_setting_heading('mod_zoom/licensesettings',
+    $settings->add(new admin_setting_heading('zoom/licensesettings',
             get_string('licensesettings', 'mod_zoom'),
             get_string('licensesettings_desc', 'mod_zoom')));
 
-    $licensescount = new admin_setting_configtext('mod_zoom/licensesnumber',
+    $licensescount = new admin_setting_configtext('zoom/licensesnumber',
             get_string('licensesnumber', 'mod_zoom'),
             null, 0, PARAM_INT);
     $settings->add($licensescount);
 
-    $utmost = new admin_setting_configcheckbox('mod_zoom/utmost',
+    $utmost = new admin_setting_configcheckbox('zoom/utmost',
             get_string('redefinelicenses', 'mod_zoom'),
             get_string('lowlicenses', 'mod_zoom'), 0, 1);
     $settings->add($utmost);
 
-    $recycleonjoin = new admin_setting_configcheckbox('mod_zoom/recycleonjoin',
+    $recycleonjoin = new admin_setting_configcheckbox('zoom/recycleonjoin',
             get_string('recycleonjoin', 'mod_zoom'),
             get_string('licenseonjoin', 'mod_zoom'), 0, 1);
     $settings->add($recycleonjoin);
 
     // Global settings.
-    $settings->add(new admin_setting_heading('mod_zoom/globalsettings',
+    $settings->add(new admin_setting_heading('zoom/globalsettings',
             get_string('globalsettings', 'mod_zoom'),
             get_string('globalsettings_desc', 'mod_zoom')));
 
@@ -103,30 +103,30 @@ if ($ADMIN->fulltree) {
     foreach ($jointimechoices as $minutes) {
         $jointimeselect[$minutes] = $minutes . ' ' . get_string('mins');
     }
-    $firstabletojoin = new admin_setting_configselect('mod_zoom/firstabletojoin',
+    $firstabletojoin = new admin_setting_configselect('zoom/firstabletojoin',
             get_string('firstjoin', 'mod_zoom'), get_string('firstjoin_desc', 'mod_zoom'),
             15, $jointimeselect);
     $settings->add($firstabletojoin);
 
-    $displaypassword = new admin_setting_configcheckbox('mod_zoom/displaypassword',
+    $displaypassword = new admin_setting_configcheckbox('zoom/displaypassword',
             get_string('displaypassword', 'mod_zoom'),
             get_string('displaypassword_help', 'mod_zoom'), 0, 1, 0);
     $settings->add($displaypassword);
 
-    $maskparticipantdata = new admin_setting_configcheckbox('mod_zoom/maskparticipantdata',
+    $maskparticipantdata = new admin_setting_configcheckbox('zoom/maskparticipantdata',
             get_string('maskparticipantdata', 'mod_zoom'),
             get_string('maskparticipantdata_help', 'mod_zoom'), 0, 1);
     $settings->add($maskparticipantdata);
 
     // Supplementary features settings.
-    $settings->add(new admin_setting_heading('mod_zoom/supplementaryfeaturessettings',
+    $settings->add(new admin_setting_heading('zoom/supplementaryfeaturessettings',
             get_string('supplementaryfeaturessettings', 'mod_zoom'),
             get_string('supplementaryfeaturessettings_desc', 'mod_zoom')));
 
     $webinarchoices = array(ZOOM_WEBINAR_DISABLE => get_string('webinar_disable', 'mod_zoom'),
             ZOOM_WEBINAR_SHOWONLYIFLICENSE => get_string('webinar_showonlyiflicense', 'mod_zoom'),
             ZOOM_WEBINAR_ALWAYSSHOW => get_string('webinar_alwaysshow', 'mod_zoom'));
-    $offerwebinar = new admin_setting_configselect('mod_zoom/showwebinars',
+    $offerwebinar = new admin_setting_configselect('zoom/showwebinars',
             get_string('webinar', 'mod_zoom'),
             get_string('webinar_desc', 'mod_zoom'),
             ZOOM_WEBINAR_ALWAYSSHOW,
@@ -136,7 +136,7 @@ if ($ADMIN->fulltree) {
     $encryptionchoices = array(ZOOM_ENCRYPTION_DISABLE => get_string('encryptiontype_disable', 'mod_zoom'),
             ZOOM_ENCRYPTION_SHOWONLYIFPOSSIBLE => get_string('encryptiontype_showonlyife2epossible', 'mod_zoom'),
             ZOOM_ENCRYPTION_ALWAYSSHOW => get_string('encryptiontype_alwaysshow', 'mod_zoom'));
-    $offerencryption = new admin_setting_configselect('mod_zoom/showencryptiontype',
+    $offerencryption = new admin_setting_configselect('zoom/showencryptiontype',
             get_string('encryptiontype', 'mod_zoom'),
             get_string('encryptiontype_desc', 'mod_zoom'),
             ZOOM_ENCRYPTION_SHOWONLYIFPOSSIBLE,
@@ -144,11 +144,11 @@ if ($ADMIN->fulltree) {
     $settings->add($offerencryption);
 
     // Default Zoom settings.
-    $settings->add(new admin_setting_heading('mod_zoom/defaultsettings',
+    $settings->add(new admin_setting_heading('zoom/defaultsettings',
             get_string('defaultsettings', 'mod_zoom'),
             get_string('defaultsettings_help', 'mod_zoom')));
 
-    $defaultrecurring = new admin_setting_configcheckbox('mod_zoom/defaultrecurring',
+    $defaultrecurring = new admin_setting_configcheckbox('zoom/defaultrecurring',
             get_string('recurringmeeting', 'mod_zoom'),
             get_string('recurringmeeting_help', 'mod_zoom'), 0, 1, 0);
     $settings->add($defaultrecurring);
@@ -162,37 +162,37 @@ if ($ADMIN->fulltree) {
 
     $encryptionchoices = array(ZOOM_ENCRYPTION_TYPE_ENHANCED => get_string('option_encryption_type_enhancedencryption', 'mod_zoom'),
             ZOOM_ENCRYPTION_TYPE_E2EE => get_string('option_encryption_type_endtoendencryption', 'mod_zoom'));
-    $defaultencryptiontypeoption = new admin_setting_configselect('mod_zoom/defaultencryptiontypeoption',
+    $defaultencryptiontypeoption = new admin_setting_configselect('zoom/defaultencryptiontypeoption',
             get_string('option_encryption_type', 'mod_zoom'),
             get_string('option_encryption_type_help', 'mod_zoom'),
             ZOOM_ENCRYPTION_TYPE_ENHANCED, $encryptionchoices);
     $settings->add($defaultencryptiontypeoption);
 
-    $defaultwaitingroomoption = new admin_setting_configcheckbox('mod_zoom/defaultwaitingroomoption',
+    $defaultwaitingroomoption = new admin_setting_configcheckbox('zoom/defaultwaitingroomoption',
             get_string('option_waiting_room', 'mod_zoom'),
             get_string('option_waiting_room_help', 'mod_zoom'),
             1, 1, 0);
     $settings->add($defaultwaitingroomoption);
 
-    $defaultjoinbeforehost = new admin_setting_configcheckbox('mod_zoom/defaultjoinbeforehost',
+    $defaultjoinbeforehost = new admin_setting_configcheckbox('zoom/defaultjoinbeforehost',
             get_string('option_jbh', 'mod_zoom'),
             get_string('option_jbh_help', 'mod_zoom'),
             0, 1, 0);
     $settings->add($defaultjoinbeforehost);
 
-    $defaultauthusersoption = new admin_setting_configcheckbox('mod_zoom/defaultauthusersoption',
+    $defaultauthusersoption = new admin_setting_configcheckbox('zoom/defaultauthusersoption',
             get_string('option_authenticated_users', 'mod_zoom'),
             get_string('option_authenticated_users_help', 'mod_zoom'),
             0, 1, 0);
     $settings->add($defaultauthusersoption);
 
-    $defaulthostvideo = new admin_setting_configcheckbox('mod_zoom/defaulthostvideo',
+    $defaulthostvideo = new admin_setting_configcheckbox('zoom/defaulthostvideo',
             get_string('option_host_video', 'mod_zoom'),
             get_string('option_host_video_help', 'mod_zoom'),
             0, 1, 0);
     $settings->add($defaulthostvideo);
 
-    $defaultparticipantsvideo = new admin_setting_configcheckbox('mod_zoom/defaultparticipantsvideo',
+    $defaultparticipantsvideo = new admin_setting_configcheckbox('zoom/defaultparticipantsvideo',
             get_string('option_participants_video', 'mod_zoom'),
             get_string('option_participants_video_help', 'mod_zoom'),
             0, 1, 0);
@@ -201,13 +201,13 @@ if ($ADMIN->fulltree) {
     $audiochoices = array(ZOOM_AUDIO_TELEPHONY => get_string('audio_telephony', 'mod_zoom'),
                           ZOOM_AUDIO_VOIP => get_string('audio_voip', 'mod_zoom'),
                           ZOOM_AUDIO_BOTH => get_string('audio_both', 'mod_zoom'));
-    $defaultaudiooption = new admin_setting_configselect('mod_zoom/defaultaudiooption',
+    $defaultaudiooption = new admin_setting_configselect('zoom/defaultaudiooption',
             get_string('option_audio', 'mod_zoom'),
             get_string('option_audio_help', 'mod_zoom'),
             ZOOM_AUDIO_BOTH, $audiochoices);
     $settings->add($defaultaudiooption);
 
-    $defaultmuteuponentryoption = new admin_setting_configcheckbox('mod_zoom/defaultmuteuponentryoption',
+    $defaultmuteuponentryoption = new admin_setting_configcheckbox('zoom/defaultmuteuponentryoption',
             get_string('option_mute_upon_entry', 'mod_zoom'),
             get_string('option_mute_upon_entry_help', 'mod_zoom'),
             1, 1, 0);

--- a/tests/mod_zoom_grade_test.php
+++ b/tests/mod_zoom_grade_test.php
@@ -42,8 +42,8 @@ class mod_zoom_grade_update_test extends advanced_testcase {
     public function setUp(): void {
         $this->resetAfterTest();
         // Set fake values for the Zoom module settings.
-        set_config('apikey', 'test', 'mod_zoom');
-        set_config('apisecret', 'test', 'mod_zoom');
+        set_config('apikey', 'test', 'zoom');
+        set_config('apisecret', 'test', 'zoom');
 
         $this->course = $this->getDataGenerator()->create_course();
         $this->teacher = $this->getDataGenerator()->create_and_enrol($this->course, 'teacher');

--- a/tests/mod_zoom_webservice_test.php
+++ b/tests/mod_zoom_webservice_test.php
@@ -42,8 +42,8 @@ class mod_zoom_webservice_test extends advanced_testcase {
     public function setUp(): void {
         $this->resetAfterTest();
         // Set fake values so we can test methods in class.
-        set_config('apikey', 'test', 'mod_zoom');
-        set_config('apisecret', 'test', 'mod_zoom');
+        set_config('apikey', 'test', 'zoom');
+        set_config('apisecret', 'test', 'zoom');
 
         $this->notfoundmockcurl = new class {
             // @codingStandardsIgnoreStart

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die();
 
 $plugin->component = 'mod_zoom';
-$plugin->version = 2021012902;
+$plugin->version = 2021012903;
 $plugin->release = 'v3.4';
 $plugin->requires = 2017051500.00;
 $plugin->maturity = MATURITY_STABLE;

--- a/view.php
+++ b/view.php
@@ -31,7 +31,7 @@ require_once(dirname(__FILE__).'/lib.php');
 require_once(dirname(__FILE__).'/locallib.php');
 require_once(dirname(__FILE__).'/../../lib/moodlelib.php');
 
-$config = get_config('mod_zoom');
+$config = get_config('zoom');
 
 list($course, $cm, $zoom) = zoom_get_instance_setup();
 
@@ -180,7 +180,7 @@ $haspassword = (isset($zoom->password) && $zoom->password !== '');
 $strhaspass = ($haspassword) ? $stryes : $strno;
 $table->data[] = array($strpassprotect, $strhaspass);
 
-if ($userishost && $haspassword || get_config('mod_zoom', 'displaypassword')) {
+if ($userishost && $haspassword || get_config('zoom', 'displaypassword')) {
     $table->data[] = array($strpassword, $zoom->password);
 }
 


### PR DESCRIPTION
This patch changes all plugin settings prefixes to use the 'zoom' prefix instead of 'mod_zoom'.
To make this transition as transparent as possible for the admin, existing settings are rewritten during an upgrade step.