### PR TITLE
Don't show 'Refresh sessions report' if not usable

### DIFF
--- a/index.php
+++ b/index.php
@@ -174,8 +174,8 @@ foreach ($zooms as $z) {
 echo $OUTPUT->heading($strnew, 4);
 echo html_writer::table($newtable);
 echo $OUTPUT->heading($strold, 4, null, 'mod-zoom-old-meetings-header');
-// Show refresh meeting sessions link only if user can edit Zoom meetings.
-if ($iszoommanager) {
+// Show refresh meeting sessions link only if user can run the 'refresh session reports' console command.
+if (has_capability('mod/zoom:refreshsessions', $context)) {
     $linkarguments = array(
         'courseid' => $id,
         'start' => date('Y-m-d', strtotime('-3 days')),


### PR DESCRIPTION
This patch solves the problem that on /mod/zoom/index.php, teachers see the 'Refresh session reports' link but can't use it.
This is realized by checking for mod/zoom:refreshsessions before showing the link.