### PR TITLE
Fix a fatal regression on settings.php for Moodle core < 3.7 - Fixes #227

### DIFF
--- a/lang/en/zoom.php
+++ b/lang/en/zoom.php
@@ -68,6 +68,7 @@ $string['defaultsettings'] = 'Default Zoom settings';
 $string['defaultsettings_help'] = 'These settings define the defaults for all new Zoom meetings and webinars.';
 $string['displayleadtime'] = 'Display lead time';
 $string['displayleadtime_desc'] = 'If enabled, the leadtime will be displayed to the users. This way, users are informed that / when they can join the meeting before the scheduled start time. This might keep users from constantly reloading the page until they can join.';
+$string['displayleadtime_nohideif'] = 'Please note: This setting is only processed if the \'{$a}\' setting is set to a value greater than zero.';
 $string['displaypassword'] = 'Display passcode';
 $string['displaypassword_help'] = 'If enabled the meeting passcode will always be displayed to non-hosts.';
 $string['downloadical'] = 'Download iCal';

--- a/settings.php
+++ b/settings.php
@@ -108,11 +108,20 @@ if ($ADMIN->fulltree) {
             15, $jointimeselect);
     $settings->add($firstabletojoin);
 
-    $displayleadtime = new admin_setting_configcheckbox('zoom/displayleadtime',
-            get_string('displayleadtime', 'mod_zoom'),
-            get_string('displayleadtime_desc', 'mod_zoom'), 0, 1, 0);
-    $settings->add($displayleadtime);
-    $settings->hide_if('zoom/displayleadtime', 'zoom/firstabletojoin', 'eq', 0);
+    if ($CFG->branch >= 37) {
+        $displayleadtime = new admin_setting_configcheckbox('zoom/displayleadtime',
+                get_string('displayleadtime', 'mod_zoom'),
+                get_string('displayleadtime_desc', 'mod_zoom'), 0, 1, 0);
+        $settings->add($displayleadtime);
+        $settings->hide_if('zoom/displayleadtime', 'zoom/firstabletojoin', 'eq', 0);
+    } else {
+        $displayleadtime = new admin_setting_configcheckbox('zoom/displayleadtime',
+                get_string('displayleadtime', 'mod_zoom'),
+                get_string('displayleadtime_desc', 'mod_zoom').'<br />'.
+                        get_string('displayleadtime_nohideif', 'mod_zoom', get_string('firstjoin', 'mod_zoom')),
+                0, 1, 0);
+        $settings->add($displayleadtime);
+    }
 
     $displaypassword = new admin_setting_configcheckbox('zoom/displaypassword',
             get_string('displaypassword', 'mod_zoom'),

--- a/settings.php
+++ b/settings.php
@@ -117,7 +117,7 @@ if ($ADMIN->fulltree) {
     } else {
         $displayleadtime = new admin_setting_configcheckbox('zoom/displayleadtime',
                 get_string('displayleadtime', 'mod_zoom'),
-                get_string('displayleadtime_desc', 'mod_zoom').'<br />'.
+                get_string('displayleadtime_desc', 'mod_zoom') . '<br />'.
                         get_string('displayleadtime_nohideif', 'mod_zoom', get_string('firstjoin', 'mod_zoom')),
                 0, 1, 0);
         $settings->add($displayleadtime);

--- a/settings.php
+++ b/settings.php
@@ -108,7 +108,7 @@ if ($ADMIN->fulltree) {
             15, $jointimeselect);
     $settings->add($firstabletojoin);
 
-    if ($CFG->branch >= 37) {
+    if (version_compare(normalize_version($CFG->release), '3.7.0', '>=')) {
         $displayleadtime = new admin_setting_configcheckbox('zoom/displayleadtime',
                 get_string('displayleadtime', 'mod_zoom'),
                 get_string('displayleadtime_desc', 'mod_zoom'), 0, 1, 0);


### PR DESCRIPTION
This patch fixes a regression which was introduced in c22c108e9c36ebf7e716939a1de8616fed800a41 but which did not handle the fact that the hide_if function does not exist before Moodle core 3.7