### PR TITLE
Fix regression which turned E2E encryption not selectable

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -283,7 +283,7 @@ class mod_zoom_mod_form extends moodleform_mod {
                 $mform->addHelpButton('option_encryption_type_group', 'option_encryption_type', 'zoom');
                 $mform->disabledIf('option_encryption_type_group', 'webinar', 'checked');
             }
-            $mform->setType('option_encryption_type', PARAM_ALPHAEXT);
+            $mform->setType('option_encryption_type', PARAM_ALPHANUMEXT);
         }
 
         // Add waiting room widget.


### PR DESCRIPTION
There was a regression in commit 05092c242f669f383825d01e285a6e5e39b07307 which set a parameter type of PARAM_ALPHAEXT for the option_encryption_type parameter. However, the E2E encryption has a parameter value of 'e2ee'. As a result, if a user selected E2E encryption during an activity creation, the form submission was denied and the 'The submitted encryption type is not valid' validation error was given.

This patch fixes this regression by simply changing the parameter type to PARAM_ALPHANUMEXT.