### PR TITLE
Update get_meeting_reports.php

### DIFF
--- a/classes/task/get_meeting_reports.php
+++ b/classes/task/get_meeting_reports.php
@@ -163,7 +163,7 @@ class get_meeting_reports extends \core\task\scheduled_task {
 
         foreach ($allmeetings as $meeting) {
             // Only process meetings if they happened after the time we left off.
-           $meetingtime = ($meeting->end_time == intval($meeting->end_time)) ? $meeting->end_time : strtotime($meeting->end_time);
+            $meetingtime = ($meeting->end_time == intval($meeting->end_time)) ? $meeting->end_time : strtotime($meeting->end_time);
             if ($runningastask && $meetingtime <= $starttime) {
                 continue;
             }

--- a/classes/task/get_meeting_reports.php
+++ b/classes/task/get_meeting_reports.php
@@ -163,7 +163,7 @@ class get_meeting_reports extends \core\task\scheduled_task {
 
         foreach ($allmeetings as $meeting) {
             // Only process meetings if they happened after the time we left off.
-            $meetingtime = strtotime($meeting->end_time);
+           $meetingtime = ($meeting->end_time == intval($meeting->end_time)) ? $meeting->end_time : strtotime($meeting->end_time);
             if ($runningastask && $meetingtime <= $starttime) {
                 continue;
             }


### PR DESCRIPTION
At least in our setup (why ?), the end_time of the meeting object is already a timestamp. Converting it using strtotime generates an empty string (at least with php v7.4.15) thus the following test is always true... never processing meeting. Proposed change should maintain compatibility with other installation while working for our server.