### PR TITLE
add view completion to moodle's webservice

### DIFF
--- a/classes/external.php
+++ b/classes/external.php
@@ -210,6 +210,10 @@ class mod_zoom_external extends external_api {
             zoom_grade_item_update($zoom, $grades);
         }
 
+        // Track completion viewed.
+        $completion = new completion_info($course);
+        $completion->set_module_viewed($cm);
+
         // Pass url to join zoom meeting in order to redirect user.
         $joinurl = new moodle_url($zoom->join_url, array('uname' => fullname($USER)));
 


### PR DESCRIPTION
This resolves issue #237 by setting the module to "viewed" in the webservice used by the mobile app before passing along the join url. (See also issue #43)