### PR TITLE
locallip.php: Remove unnecessary argument type

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -667,7 +667,7 @@ function zoom_get_nonusers_from_alternativehosts(array $alternativehosts) {
  *
  * @return string The unavailability note.
  */
-function zoom_get_unavailability_note(object $zoom, $finished = null) {
+function zoom_get_unavailability_note($zoom, $finished = null) {
     // Get config.
     $config = get_config('zoom');
 


### PR DESCRIPTION
`stdClass` does not count as `object` until PHP 7.2, so this broke users on PHP 7.1

Fixes #241 